### PR TITLE
Use continuations for faster Effect evaluation

### DIFF
--- a/FastDownward.hs
+++ b/FastDownward.hs
@@ -304,7 +304,18 @@ modifyVar v f =
 newtype Effect a =
   Effect { runEffect :: StateT EffectState ( ListT IO ) a }
   deriving
-    ( Functor, Applicative, Alternative, MonadPlus, MonadFail, Monad )
+    ( Functor, Applicative, Alternative, MonadPlus, MonadFail )
+
+
+instance Monad Effect where
+  return =
+    pure
+
+  Effect a >>= f =
+    Effect ( a >>= runEffect . f )
+
+  fail _ =
+    Effect ( lift mzero )
 
 
 -- | Used to track the evaluation of an 'Effect' as we enumerate all possible

--- a/FastDownward.hs
+++ b/FastDownward.hs
@@ -49,7 +49,7 @@ module FastDownward
   where
 
 import Control.Applicative ( Alternative )
-import Control.Monad ( MonadPlus )
+import Control.Monad ( MonadPlus, mzero )
 import Control.Monad.Fail ( MonadFail )
 import Control.Monad.IO.Class ( MonadIO, liftIO )
 import Control.Monad.State.Class ( get, gets, modify )

--- a/fast-downward.cabal
+++ b/fast-downward.cabal
@@ -59,7 +59,6 @@ library
   build-depends:
     base         ^>= 4.11.1.0 || ^>= 4.12.0.0,
     containers   ^>= 0.5.11.0 || ^>= 0.6,
-    list-t       ^>= 1.0.2,
     mtl          ^>= 2.2.2,
     process      ^>= 1.6.3.0,
     temporary    ^>= 1.3,


### PR DESCRIPTION
This commit changes how `readVar` and `writeVar` work to provide a vastly faster translation step. The previous approach was to try and exhaustively enumerate all branches of all given `Effect`s, and to collect the writes at the end. If we saw new writes, we would naively repeat the process - enumerating *all* `Effect`s again, even if a very marginal variable had changed.

The change here is to instead use continuations to capture whenever a variable is read. On read, we capture the rest of the computation and "subscribe" it to the variable, such that whenever it is written to, the continuation is invoked with the new value. This means evaluation is compact - when a variable changes, only other `Effect`s that read it will be re-evaluated, and even then only the new branches.