### PR TITLE
Prevail unchanged writes

### DIFF
--- a/FastDownward.hs
+++ b/FastDownward.hs
@@ -304,7 +304,18 @@ modifyVar v f =
 newtype Effect a =
   Effect { runEffect :: StateT EffectState ( ListT IO ) a }
   deriving
-    ( Functor, Applicative, Alternative, MonadPlus, MonadFail, Monad )
+    ( Functor, Applicative, Alternative, MonadPlus, MonadFail )
+
+
+instance Monad Effect where
+  return =
+    pure
+
+  Effect a >>= f =
+    Effect ( a >>= runEffect . f )
+
+  fail _ =
+    Effect ( lift mzero )
 
 
 -- | Used to track the evaluation of an 'Effect' as we enumerate all possible

--- a/FastDownward.hs
+++ b/FastDownward.hs
@@ -487,18 +487,34 @@ solve cfg ops tests = do
           , operators =
               zipWith
                 ( \i ( _, EffectState{ reads, writes } ) ->
+                    let
+                      unchangedWrites =
+                        Map.differenceWith
+                          ( \a b -> if fst a == fst b then Just a else Nothing )
+                          writes
+                          reads
+
+                      actualWrites =
+                        writes `Map.difference` unchangedWrites
+
+                    in
                     FastDownward.SAS.Operator
                       { name = fromString ( "op" <> show i )
                       , prevail =
                           map
                             ( uncurry FastDownward.SAS.VariableAssignment )
                             ( Map.toList
-                                ( fst <$> Map.difference reads writes )
+                                ( fmap
+                                    fst
+                                    ( Map.difference reads writes
+                                        <> unchangedWrites
+                                    )
+                                )
                             )
                       , effects =
                           map
                             ( \( v, ( post, _ ) ) -> FastDownward.SAS.Effect v Nothing post )
-                            ( Map.toList ( Map.difference writes reads ) )
+                            ( Map.toList ( writes `Map.difference` reads ) )
                             ++
                               Map.elems
                                 ( Map.intersectionWithKey
@@ -506,7 +522,7 @@ solve cfg ops tests = do
                                         FastDownward.SAS.Effect v ( Just pre ) post
                                     )
                                     ( fst <$> reads )
-                                    ( fst <$> writes )
+                                    ( fst <$> actualWrites )
                                 )
                       }
                 )

--- a/FastDownward.hs
+++ b/FastDownward.hs
@@ -49,7 +49,7 @@ module FastDownward
   where
 
 import Control.Applicative ( Alternative )
-import Control.Monad ( MonadPlus )
+import Control.Monad ( MonadPlus, mzero )
 import Control.Monad.Fail ( MonadFail )
 import Control.Monad.IO.Class ( MonadIO, liftIO )
 import Control.Monad.State.Class ( get, gets, modify )

--- a/fast-downward.cabal
+++ b/fast-downward.cabal
@@ -59,7 +59,6 @@ library
   build-depends:
     base         ^>= 4.11.1.0 || ^>= 4.12.0.0,
     containers   ^>= 0.5.11.0 || ^>= 0.6,
-    list-t       ^>= 1.0.2,
     mtl          ^>= 2.2.2,
     process      ^>= 1.6.3.0,
     temporary    ^>= 1.3,


### PR DESCRIPTION
This change means that if you do `readVar v >>= writeVar v`, this will be registered the same as just `readVar v` - that is, a prevailing condition for the effect. This allows one to internal use a variable to sequence an `Effect`, and then restore it to its original state at the end. This can be useful for temporarily swapping variables via some intermediary variable (that is always empty).