### PR TITLE
1.2.03.0 -> 1.2.3.0

### DIFF
--- a/fast-downward.cabal
+++ b/fast-downward.cabal
@@ -62,7 +62,7 @@ library
     mtl          ^>= 2.2.2,
     process      ^>= 1.6.3.0,
     temporary    ^>= 1.3,
-    text         ^>= 1.2.03.0,
+    text         ^>= 1.2.3.0,
     transformers ^>= 0.5.5.0
   default-language:
     Haskell2010


### PR DESCRIPTION
`Cabal` won't accept leading zeroes in versions (and also Hackage).