### PR TITLE
Prevent planner from locking up on large problems.

### DIFF
--- a/FastDownward/Exec.hs
+++ b/FastDownward/Exec.hs
@@ -129,6 +129,7 @@ module FastDownward.Exec
   )
   where
 
+import Control.Concurrent.Async (concurrently)
 import Control.Monad.IO.Class ( MonadIO, liftIO )
 import Data.Char
 import Data.List
@@ -295,11 +296,9 @@ callFastDownward Options{ fastDownward, problem, planFilePath, searchConfigurati
   Data.Text.Lazy.IO.hPutStr writeProblemHandle ( FastDownward.SAS.Plan.toSAS problem )
     >> hClose writeProblemHandle
 
-  stdout <-
-    Data.Text.IO.hGetContents stdoutHandle
-
-  stderr <-
-    Data.Text.IO.hGetContents stderrHandle
+  (stderr, stdout) <- concurrently
+        (Data.Text.IO.hGetContents stderrHandle)
+        (Data.Text.IO.hGetContents stdoutHandle)
 
   exitCode <-
     waitForProcess processHandle

--- a/FastDownward/Exec.hs
+++ b/FastDownward/Exec.hs
@@ -134,7 +134,8 @@ import Data.Char
 import Data.List
 import Data.Maybe
 import Data.Ratio
-import qualified Data.Text.Lazy
+import qualified Data.Text
+import qualified Data.Text.IO
 import qualified Data.Text.Lazy.IO
 import qualified FastDownward.SAS
 import qualified FastDownward.SAS.Plan
@@ -294,16 +295,16 @@ callFastDownward Options{ fastDownward, problem, planFilePath, searchConfigurati
   Data.Text.Lazy.IO.hPutStr writeProblemHandle ( FastDownward.SAS.Plan.toSAS problem )
     >> hClose writeProblemHandle
 
+  stdout <-
+    Data.Text.IO.hGetContents stdoutHandle
+
+  stderr <-
+    Data.Text.IO.hGetContents stderrHandle
+
   exitCode <-
     waitForProcess processHandle
 
-  stdout <-
-    Data.Text.Lazy.IO.hGetContents stdoutHandle
-
-  stderr <-
-    Data.Text.Lazy.IO.hGetContents stderrHandle
-
-  return ( exitCode, Data.Text.Lazy.unpack stdout, Data.Text.Lazy.unpack stderr )
+  return ( exitCode, Data.Text.unpack stdout, Data.Text.unpack stderr )
 
 
 -- | See <http://www.fast-downward.org/Doc/SearchEngine>

--- a/fast-downward.cabal
+++ b/fast-downward.cabal
@@ -58,6 +58,7 @@ library
     FastDownward.SAS.Version
   build-depends:
     base         ^>= 4.11.1.0 || ^>= 4.12.0.0 || ^>= 4.13.0.0,
+    async        ^>= 2.2.0,
     containers   ^>= 0.5.11.0 || ^>= 0.6,
     mtl          ^>= 2.2.2,
     process      ^>= 1.6.3.0,


### PR DESCRIPTION
In some scenarios, the `downward` executable was producing a lot of
output which was not being read by the library. This would eventually
cause the downward process to hang, waiting for someone to consume its
output. This change drains both output handles before calling wait, and
thus preventing the deadlock.